### PR TITLE
Inline FormatSpecifierParser into static method

### DIFF
--- a/src/java.base/share/classes/java/util/FormatProcessor.java
+++ b/src/java.base/share/classes/java/util/FormatProcessor.java
@@ -217,7 +217,6 @@ public final class FormatProcessor implements Processor<String, RuntimeException
      * @throws MissingFormatArgumentException if not at end or found and not needed
      */
     private static boolean findFormat(String fragment, boolean needed) {
-        Formatter.FormatSpecifierParser parser = null;
         int max = fragment.length();
         for (int i = 0; i < max;) {
             int n = fragment.indexOf('%', i);
@@ -231,14 +230,11 @@ public final class FormatProcessor implements Processor<String, RuntimeException
             }
 
             char c = fragment.charAt(i);
-            if (parser == null) {
-                parser = new Formatter.FormatSpecifierParser(null, c, i, fragment, max);
-            } else {
-                parser.reset(c, i);
+            if (Formatter.isConversion(c)) {
+                return true;
             }
-
             String group;
-            int off = parser.parse();
+            int off = Formatter.parse(null, c, i, fragment, max);
 
             if (off == 1) {
                 char c1 = fragment.charAt(off);


### PR DESCRIPTION
The `FormatSpecifierParser` seems somewhat superfluous and could be inlined:
```
Name                                Cnt     Base     Error      Test     Error   Unit  Change
StringFormat.complexFormat            5  831,560 ±  17,808   768,936 ±  15,902  ns/op   1,08x (p = 0,000*)
  :gc.alloc.rate                        1779,694 ±  38,214  1865,120 ±  38,709 MB/sec   0,95x (p = 0,000*)
  :gc.alloc.rate.norm                   1552,006 ±   0,000  1504,005 ±   0,000   B/op   1,03x (p = 0,000*)
  :gc.count                               30,000              31,000           counts
  :gc.time                                17,000              18,000               ms
  ```