### PR TITLE
Add specialized CharArraySequence

### DIFF
--- a/src/java.base/share/classes/java/math/BigDecimal.java
+++ b/src/java.base/share/classes/java/math/BigDecimal.java
@@ -541,15 +541,7 @@ public class BigDecimal extends Number implements Comparable<BigDecimal> {
      * @since  1.5
      */
     public BigDecimal(char[] in, int offset, int len, MathContext mc) {
-        this(wrap(in, offset, len), mc);
-    }
-
-    private static CharSequence wrap(char[] in, int offset, int len) {
-        try {
-            return CharBuffer.wrap(in, offset, len);
-        } catch (IndexOutOfBoundsException ignored) {
-            throw new NumberFormatException();
-        }
+        this(new CharArraySequence(in, offset, len), mc);
     }
 
     /*
@@ -638,6 +630,29 @@ public class BigDecimal extends Number implements Comparable<BigDecimal> {
      */
     public BigDecimal(char[] in, MathContext mc) {
         this(in, 0, in.length, mc);
+    }
+
+    private record CharArraySequence(char[] array, int start, int end) implements CharSequence {
+        CharArraySequence {
+            if (start < 0 || start > end) {
+                throw new NumberFormatException();
+            }
+        }
+
+        @Override
+        public int length() {
+            return end - start;
+        }
+
+        @Override
+        public char charAt(int index) {
+            return array[start + index];
+        }
+
+        @Override
+        public CharSequence subSequence(int start, int end) {
+            throw new UnsupportedOperationException();
+        }
     }
 
     /**


### PR DESCRIPTION
```
Name                                          Cnt     Base     Error      Test     Error   Unit  Change
BigDecimals.testConstructorWithCharArray       15   54,821 ±   8,817    47,733 ±  10,806  ns/op   1,15x (p = 0,045 )
  :gc.alloc.rate                                  2263,846 ± 286,703  1983,129 ± 358,096 MB/sec   0,88x (p = 0,017 )
  :gc.alloc.rate.norm                              128,000 ±   0,000    96,000 ±   0,000   B/op   0,75x (p = 0,000*)
  :gc.count                                        115,000             100,000           counts
  :gc.time                                          76,000              67,000               ms
BigDecimals.testConstructorWithHugeCharArray   15   87,734 ±   0,591    69,999 ±   3,929  ns/op   1,25x (p = 0,000*)
  :gc.alloc.rate                                  1739,047 ±  11,559  1748,119 ±  98,202 MB/sec   1,01x (p = 0,710 )
  :gc.alloc.rate.norm                              160,001 ±   0,000   128,000 ±   0,000   B/op   0,80x (p = 0,000*)
  :gc.count                                         88,000              88,000           counts
  :gc.time                                          58,000              60,000               ms
BigDecimals.testConstructorWithLargeCharArray  15   90,333 ±   3,675    68,787 ±   5,520  ns/op   1,31x (p = 0,000*)
  :gc.alloc.rate                                  1691,063 ±  68,864  1783,294 ± 136,845 MB/sec   1,05x (p = 0,021 )
  :gc.alloc.rate.norm                              160,001 ±   0,000   128,000 ±   0,000   B/op   0,80x (p = 0,000*)
  :gc.count                                         85,000              91,000           counts
  :gc.time                                          67,000              62,000               ms
BigDecimals.testConstructorWithSmallCharArray  15   21,669 ±   0,258    18,714 ±   0,116  ns/op   1,16x (p = 0,000*)
  :gc.alloc.rate                                  4224,840 ±  50,161  3261,059 ±  20,162 MB/sec   0,77x (p = 0,000*)
  :gc.alloc.rate.norm                               96,000 ±   0,000    64,000 ±   0,000   B/op   0,67x (p = 0,000*)
  :gc.count                                        208,000             163,000           counts
  :gc.time                                         127,000             101,000               ms
  * = significant
```