### PR TITLE
Cleanup/unsafe long offset

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/VarHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarHandles.java
@@ -196,7 +196,7 @@ final class VarHandles {
 
         Class<?> componentType = arrayClass.getComponentType();
 
-        int aoffset = UNSAFE.arrayBaseOffset(arrayClass);
+        int aoffset = (int) UNSAFE.arrayBaseOffset(arrayClass);
         int ascale = UNSAFE.arrayIndexScale(arrayClass);
         int ashift = 31 - Integer.numberOfLeadingZeros(ascale);
 

--- a/src/java.base/share/classes/java/util/concurrent/ConcurrentHashMap.java
+++ b/src/java.base/share/classes/java/util/concurrent/ConcurrentHashMap.java
@@ -6382,7 +6382,7 @@ public class ConcurrentHashMap<K,V> extends AbstractMap<K,V>
         = U.objectFieldOffset(ConcurrentHashMap.class, "cellsBusy");
     private static final long CELLVALUE
         = U.objectFieldOffset(CounterCell.class, "value");
-    private static final int ABASE = U.arrayBaseOffset(Node[].class);
+    private static final long ABASE = U.arrayBaseOffset(Node[].class);
     private static final int ASHIFT;
 
     static {

--- a/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
+++ b/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
@@ -1044,7 +1044,7 @@ public final class Unsafe {
      * {@link #staticFieldOffset}, {@link #objectFieldOffset},
      * or {@link #arrayBaseOffset}.
      * <p>
-     * The static type is @code long} to emphasize that long arithmetics should
+     * The static type is @code long} to emphasize that long arithmetic should
      * always be used for offset calculations to avoid overflows.
      */
     public static final long INVALID_FIELD_OFFSET = -1;
@@ -1177,7 +1177,7 @@ public final class Unsafe {
      * given class.
      * <p>
      * The return value is in the range of a {@code int}.  The return type is
-     * {@code long} to emphasize that long arithmetics should always be used
+     * {@code long} to emphasize that long arithmetic should always be used
      * for offset calculations to avoid overflows.
      *
      * @see #getInt(Object, long)
@@ -1236,7 +1236,7 @@ public final class Unsafe {
      * as zero.
      * <p>
      * The computation of the actual memory offset should always use {@code
-     * long} arithmetics to avoid overflows.
+     * long} arithmetic to avoid overflows.
      *
      * @see #arrayBaseOffset
      * @see #getInt(Object, long)
@@ -3850,7 +3850,7 @@ public final class Unsafe {
     private native Object staticFieldBase0(Field f);
     private native boolean shouldBeInitialized0(Class<?> c);
     private native void ensureClassInitialized0(Class<?> c);
-    private native int arrayBaseOffset0(Class<?> arrayClass); // public version returns long to promote correct arithmetics
+    private native int arrayBaseOffset0(Class<?> arrayClass); // public version returns long to promote correct arithmetic
     private native int arrayIndexScale0(Class<?> arrayClass);
     private native int getLoadAverage0(double[] loadavg, int nelems);
 

--- a/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
+++ b/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
@@ -1043,8 +1043,11 @@ public final class Unsafe {
      * This constant differs from all results that will ever be returned from
      * {@link #staticFieldOffset}, {@link #objectFieldOffset},
      * or {@link #arrayBaseOffset}.
+     * <p>
+     * The static type is @code long} to emphasize that long arithmetics should
+     * always be used for offset calculations to avoid overflows.
      */
-    public static final int INVALID_FIELD_OFFSET = -1;
+    public static final long INVALID_FIELD_OFFSET = -1;
 
     /**
      * Reports the location of a given field in the storage allocation of its
@@ -1172,11 +1175,15 @@ public final class Unsafe {
      * for the same class, you may use that scale factor, together with this
      * base offset, to form new offsets to access elements of arrays of the
      * given class.
+     * <p>
+     * The return value is in the range of a {@code int}.  The return type is
+     * {@code long} to emphasize that long arithmetics should always be used
+     * for offset calculations to avoid overflows.
      *
      * @see #getInt(Object, long)
      * @see #putInt(Object, long, int)
      */
-    public int arrayBaseOffset(Class<?> arrayClass) {
+    public long arrayBaseOffset(Class<?> arrayClass) {
         if (arrayClass == null) {
             throw new NullPointerException();
         }
@@ -1227,6 +1234,9 @@ public final class Unsafe {
      * will generally not work properly with accessors like {@link
      * #getByte(Object, long)}, so the scale factor for such classes is reported
      * as zero.
+     * <p>
+     * The computation of the actual memory offset should always use {@code
+     * long} arithmetics to avoid overflows.
      *
      * @see #arrayBaseOffset
      * @see #getInt(Object, long)
@@ -3840,7 +3850,7 @@ public final class Unsafe {
     private native Object staticFieldBase0(Field f);
     private native boolean shouldBeInitialized0(Class<?> c);
     private native void ensureClassInitialized0(Class<?> c);
-    private native int arrayBaseOffset0(Class<?> arrayClass);
+    private native int arrayBaseOffset0(Class<?> arrayClass); // public version returns long to promote correct arithmetics
     private native int arrayIndexScale0(Class<?> arrayClass);
     private native int getLoadAverage0(double[] loadavg, int nelems);
 

--- a/src/jdk.unsupported/share/classes/sun/misc/Unsafe.java
+++ b/src/jdk.unsupported/share/classes/sun/misc/Unsafe.java
@@ -863,7 +863,7 @@ public final class Unsafe {
      * @deprecated Not needed when using {@link VarHandle} or {@link java.lang.foreign}.
      */
     @Deprecated(since="23", forRemoval=true)
-    public static final int INVALID_FIELD_OFFSET = jdk.internal.misc.Unsafe.INVALID_FIELD_OFFSET;
+    public static final int INVALID_FIELD_OFFSET = (int) jdk.internal.misc.Unsafe.INVALID_FIELD_OFFSET;
 
     /**
      * Reports the location of a given field in the storage allocation of its
@@ -994,7 +994,7 @@ public final class Unsafe {
     @ForceInline
     public int arrayBaseOffset(Class<?> arrayClass) {
         beforeMemoryAccess();
-        return theInternalUnsafe.arrayBaseOffset(arrayClass);
+        return (int) theInternalUnsafe.arrayBaseOffset(arrayClass);
     }
 
     /** The value of {@code arrayBaseOffset(boolean[].class)}.

--- a/test/hotspot/jtreg/compiler/c2/Test6968348.java
+++ b/test/hotspot/jtreg/compiler/c2/Test6968348.java
@@ -39,7 +39,7 @@ import java.lang.reflect.Field;
 public class Test6968348 {
     static Unsafe unsafe = Unsafe.getUnsafe();
     static final long[] buffer = new long[4096];
-    static int array_long_base_offset;
+    static long array_long_base_offset;
 
     public static void main(String[] args) throws Exception {
         array_long_base_offset = unsafe.arrayBaseOffset(long[].class);

--- a/test/hotspot/jtreg/compiler/c2/cr8004867/TestIntUnsafeCAS.java
+++ b/test/hotspot/jtreg/compiler/c2/cr8004867/TestIntUnsafeCAS.java
@@ -50,7 +50,7 @@ public class TestIntUnsafeCAS {
   private static final int UNALIGN_OFF = 5;
 
   private static final Unsafe unsafe = Unsafe.getUnsafe();
-  private static final int BASE;
+  private static final long BASE;
   static {
     try {
       BASE = unsafe.arrayBaseOffset(int[].class);

--- a/test/hotspot/jtreg/compiler/c2/cr8004867/TestIntUnsafeOrdered.java
+++ b/test/hotspot/jtreg/compiler/c2/cr8004867/TestIntUnsafeOrdered.java
@@ -50,7 +50,7 @@ public class TestIntUnsafeOrdered {
   private static final int UNALIGN_OFF = 5;
 
   private static final Unsafe unsafe = Unsafe.getUnsafe();
-  private static final int BASE;
+  private static final long BASE;
   static {
     try {
       BASE = unsafe.arrayBaseOffset(int[].class);

--- a/test/hotspot/jtreg/compiler/c2/cr8004867/TestIntUnsafeVolatile.java
+++ b/test/hotspot/jtreg/compiler/c2/cr8004867/TestIntUnsafeVolatile.java
@@ -50,7 +50,7 @@ public class TestIntUnsafeVolatile {
   private static final int UNALIGN_OFF = 5;
 
   private static final Unsafe unsafe = Unsafe.getUnsafe();
-  private static final int BASE;
+  private static final long BASE;
   static {
     try {
       BASE = unsafe.arrayBaseOffset(int[].class);

--- a/test/hotspot/jtreg/compiler/unsafe/JdkInternalMiscUnsafeAccessTestBoolean.java
+++ b/test/hotspot/jtreg/compiler/unsafe/JdkInternalMiscUnsafeAccessTestBoolean.java
@@ -60,7 +60,7 @@ public class JdkInternalMiscUnsafeAccessTestBoolean {
 
     static final long STATIC_V_OFFSET;
 
-    static int ARRAY_OFFSET;
+    static long ARRAY_OFFSET;
 
     static int ARRAY_SHIFT;
 

--- a/test/hotspot/jtreg/compiler/unsafe/JdkInternalMiscUnsafeAccessTestByte.java
+++ b/test/hotspot/jtreg/compiler/unsafe/JdkInternalMiscUnsafeAccessTestByte.java
@@ -60,7 +60,7 @@ public class JdkInternalMiscUnsafeAccessTestByte {
 
     static final long STATIC_V_OFFSET;
 
-    static int ARRAY_OFFSET;
+    static long ARRAY_OFFSET;
 
     static int ARRAY_SHIFT;
 

--- a/test/hotspot/jtreg/compiler/unsafe/JdkInternalMiscUnsafeAccessTestChar.java
+++ b/test/hotspot/jtreg/compiler/unsafe/JdkInternalMiscUnsafeAccessTestChar.java
@@ -60,7 +60,7 @@ public class JdkInternalMiscUnsafeAccessTestChar {
 
     static final long STATIC_V_OFFSET;
 
-    static int ARRAY_OFFSET;
+    static long ARRAY_OFFSET;
 
     static int ARRAY_SHIFT;
 

--- a/test/hotspot/jtreg/compiler/unsafe/JdkInternalMiscUnsafeAccessTestDouble.java
+++ b/test/hotspot/jtreg/compiler/unsafe/JdkInternalMiscUnsafeAccessTestDouble.java
@@ -60,7 +60,7 @@ public class JdkInternalMiscUnsafeAccessTestDouble {
 
     static final long STATIC_V_OFFSET;
 
-    static int ARRAY_OFFSET;
+    static long ARRAY_OFFSET;
 
     static int ARRAY_SHIFT;
 

--- a/test/hotspot/jtreg/compiler/unsafe/JdkInternalMiscUnsafeAccessTestFloat.java
+++ b/test/hotspot/jtreg/compiler/unsafe/JdkInternalMiscUnsafeAccessTestFloat.java
@@ -60,7 +60,7 @@ public class JdkInternalMiscUnsafeAccessTestFloat {
 
     static final long STATIC_V_OFFSET;
 
-    static int ARRAY_OFFSET;
+    static long ARRAY_OFFSET;
 
     static int ARRAY_SHIFT;
 

--- a/test/hotspot/jtreg/compiler/unsafe/JdkInternalMiscUnsafeAccessTestInt.java
+++ b/test/hotspot/jtreg/compiler/unsafe/JdkInternalMiscUnsafeAccessTestInt.java
@@ -60,7 +60,7 @@ public class JdkInternalMiscUnsafeAccessTestInt {
 
     static final long STATIC_V_OFFSET;
 
-    static int ARRAY_OFFSET;
+    static long ARRAY_OFFSET;
 
     static int ARRAY_SHIFT;
 

--- a/test/hotspot/jtreg/compiler/unsafe/JdkInternalMiscUnsafeAccessTestLong.java
+++ b/test/hotspot/jtreg/compiler/unsafe/JdkInternalMiscUnsafeAccessTestLong.java
@@ -60,7 +60,7 @@ public class JdkInternalMiscUnsafeAccessTestLong {
 
     static final long STATIC_V_OFFSET;
 
-    static int ARRAY_OFFSET;
+    static long ARRAY_OFFSET;
 
     static int ARRAY_SHIFT;
 

--- a/test/hotspot/jtreg/compiler/unsafe/JdkInternalMiscUnsafeAccessTestObject.java
+++ b/test/hotspot/jtreg/compiler/unsafe/JdkInternalMiscUnsafeAccessTestObject.java
@@ -60,7 +60,7 @@ public class JdkInternalMiscUnsafeAccessTestObject {
 
     static final long STATIC_V_OFFSET;
 
-    static int ARRAY_OFFSET;
+    static long ARRAY_OFFSET;
 
     static int ARRAY_SHIFT;
 

--- a/test/hotspot/jtreg/compiler/unsafe/JdkInternalMiscUnsafeAccessTestShort.java
+++ b/test/hotspot/jtreg/compiler/unsafe/JdkInternalMiscUnsafeAccessTestShort.java
@@ -60,7 +60,7 @@ public class JdkInternalMiscUnsafeAccessTestShort {
 
     static final long STATIC_V_OFFSET;
 
-    static int ARRAY_OFFSET;
+    static long ARRAY_OFFSET;
 
     static int ARRAY_SHIFT;
 

--- a/test/hotspot/jtreg/compiler/unsafe/SunMiscUnsafeAccessTestBoolean.java
+++ b/test/hotspot/jtreg/compiler/unsafe/SunMiscUnsafeAccessTestBoolean.java
@@ -60,7 +60,7 @@ public class SunMiscUnsafeAccessTestBoolean {
 
     static final long STATIC_V_OFFSET;
 
-    static int ARRAY_OFFSET;
+    static long ARRAY_OFFSET;
 
     static int ARRAY_SHIFT;
 

--- a/test/hotspot/jtreg/compiler/unsafe/SunMiscUnsafeAccessTestByte.java
+++ b/test/hotspot/jtreg/compiler/unsafe/SunMiscUnsafeAccessTestByte.java
@@ -60,7 +60,7 @@ public class SunMiscUnsafeAccessTestByte {
 
     static final long STATIC_V_OFFSET;
 
-    static int ARRAY_OFFSET;
+    static long ARRAY_OFFSET;
 
     static int ARRAY_SHIFT;
 

--- a/test/hotspot/jtreg/compiler/unsafe/SunMiscUnsafeAccessTestChar.java
+++ b/test/hotspot/jtreg/compiler/unsafe/SunMiscUnsafeAccessTestChar.java
@@ -60,7 +60,7 @@ public class SunMiscUnsafeAccessTestChar {
 
     static final long STATIC_V_OFFSET;
 
-    static int ARRAY_OFFSET;
+    static long ARRAY_OFFSET;
 
     static int ARRAY_SHIFT;
 

--- a/test/hotspot/jtreg/compiler/unsafe/SunMiscUnsafeAccessTestDouble.java
+++ b/test/hotspot/jtreg/compiler/unsafe/SunMiscUnsafeAccessTestDouble.java
@@ -60,7 +60,7 @@ public class SunMiscUnsafeAccessTestDouble {
 
     static final long STATIC_V_OFFSET;
 
-    static int ARRAY_OFFSET;
+    static long ARRAY_OFFSET;
 
     static int ARRAY_SHIFT;
 

--- a/test/hotspot/jtreg/compiler/unsafe/SunMiscUnsafeAccessTestFloat.java
+++ b/test/hotspot/jtreg/compiler/unsafe/SunMiscUnsafeAccessTestFloat.java
@@ -60,7 +60,7 @@ public class SunMiscUnsafeAccessTestFloat {
 
     static final long STATIC_V_OFFSET;
 
-    static int ARRAY_OFFSET;
+    static long ARRAY_OFFSET;
 
     static int ARRAY_SHIFT;
 

--- a/test/hotspot/jtreg/compiler/unsafe/SunMiscUnsafeAccessTestInt.java
+++ b/test/hotspot/jtreg/compiler/unsafe/SunMiscUnsafeAccessTestInt.java
@@ -60,7 +60,7 @@ public class SunMiscUnsafeAccessTestInt {
 
     static final long STATIC_V_OFFSET;
 
-    static int ARRAY_OFFSET;
+    static long ARRAY_OFFSET;
 
     static int ARRAY_SHIFT;
 

--- a/test/hotspot/jtreg/compiler/unsafe/SunMiscUnsafeAccessTestLong.java
+++ b/test/hotspot/jtreg/compiler/unsafe/SunMiscUnsafeAccessTestLong.java
@@ -60,7 +60,7 @@ public class SunMiscUnsafeAccessTestLong {
 
     static final long STATIC_V_OFFSET;
 
-    static int ARRAY_OFFSET;
+    static long ARRAY_OFFSET;
 
     static int ARRAY_SHIFT;
 

--- a/test/hotspot/jtreg/compiler/unsafe/SunMiscUnsafeAccessTestObject.java
+++ b/test/hotspot/jtreg/compiler/unsafe/SunMiscUnsafeAccessTestObject.java
@@ -60,7 +60,7 @@ public class SunMiscUnsafeAccessTestObject {
 
     static final long STATIC_V_OFFSET;
 
-    static int ARRAY_OFFSET;
+    static long ARRAY_OFFSET;
 
     static int ARRAY_SHIFT;
 

--- a/test/hotspot/jtreg/compiler/unsafe/SunMiscUnsafeAccessTestShort.java
+++ b/test/hotspot/jtreg/compiler/unsafe/SunMiscUnsafeAccessTestShort.java
@@ -60,7 +60,7 @@ public class SunMiscUnsafeAccessTestShort {
 
     static final long STATIC_V_OFFSET;
 
-    static int ARRAY_OFFSET;
+    static long ARRAY_OFFSET;
 
     static int ARRAY_SHIFT;
 

--- a/test/hotspot/jtreg/compiler/unsafe/X-UnsafeAccessTest.java.template
+++ b/test/hotspot/jtreg/compiler/unsafe/X-UnsafeAccessTest.java.template
@@ -64,7 +64,7 @@ public class $Qualifier$UnsafeAccessTest$Type$ {
 
     static final long STATIC_V_OFFSET;
 
-    static int ARRAY_OFFSET;
+    static long ARRAY_OFFSET;
 
     static int ARRAY_SHIFT;
 

--- a/test/hotspot/jtreg/runtime/FieldLayout/BaseOffsets.java
+++ b/test/hotspot/jtreg/runtime/FieldLayout/BaseOffsets.java
@@ -110,8 +110,8 @@ public class BaseOffsets {
     public static final WhiteBox WB = WhiteBox.getWhiteBox();
 
     static final long INT_OFFSET;
-    static final int  INT_ARRAY_OFFSET;
-    static final int  LONG_ARRAY_OFFSET;
+    static final long INT_ARRAY_OFFSET;
+    static final long LONG_ARRAY_OFFSET;
     static {
         if (!Platform.is64bit() || WB.getBooleanVMFlag("UseCompactObjectHeaders")) {
             INT_OFFSET = 8;
@@ -151,7 +151,7 @@ public class BaseOffsets {
         Asserts.assertEquals(unsafe.arrayBaseOffset(double[].class),  LONG_ARRAY_OFFSET, "Misplaced double  array base");
         boolean narrowOops = System.getProperty("java.vm.compressedOopsMode") != null ||
                              !Platform.is64bit();
-        int expected_objary_offset = narrowOops ? INT_ARRAY_OFFSET : LONG_ARRAY_OFFSET;
+        long expected_objary_offset = narrowOops ? INT_ARRAY_OFFSET : LONG_ARRAY_OFFSET;
         Asserts.assertEquals(unsafe.arrayBaseOffset(Object[].class),  expected_objary_offset, "Misplaced object  array base");
     }
 }

--- a/test/hotspot/jtreg/runtime/Unsafe/GetField.java
+++ b/test/hotspot/jtreg/runtime/Unsafe/GetField.java
@@ -37,11 +37,11 @@ import static jdk.test.lib.Asserts.*;
 public class GetField {
     public static void main(String args[]) throws Exception {
         Unsafe unsafe = Unsafe.getUnsafe();
-        // Unsafe.INVALID_FIELD_OFFSET is a static final int field,
+        // Unsafe.INVALID_FIELD_OFFSET is a static final long field,
         // make sure getField returns the correct field
         Field field = Unsafe.class.getField("INVALID_FIELD_OFFSET");
         assertNotEquals(field.getModifiers() & Modifier.FINAL, 0);
         assertNotEquals(field.getModifiers() & Modifier.STATIC, 0);
-        assertEquals(field.getType(), int.class);
+        assertEquals(field.getType(), long.class);
     }
 }

--- a/test/micro/org/openjdk/bench/java/lang/foreign/BulkOps.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/BulkOps.java
@@ -69,7 +69,7 @@ public class BulkOps {
 
     final int[] ints = new int[ELEM_SIZE];
     final MemorySegment bytesSegment = MemorySegment.ofArray(ints);
-    final int UNSAFE_INT_OFFSET = unsafe.arrayBaseOffset(int[].class);
+    final long UNSAFE_INT_OFFSET = unsafe.arrayBaseOffset(int[].class);
 
     // large(ish) segments/buffers with same content, 0, for mismatch, non-multiple-of-8 sized
     static final int SIZE_WITH_TAIL = (1024 * 1024) + 7;

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNonConstantHeap.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNonConstantHeap.java
@@ -57,8 +57,8 @@ public class LoopOverNonConstantHeap extends JavaLayouts {
     static final int ELEM_SIZE = 1_000_000;
     static final int CARRIER_SIZE = (int)JAVA_INT.byteSize();
     static final int ALLOC_SIZE = ELEM_SIZE * CARRIER_SIZE;
-    static final int UNSAFE_BYTE_BASE = unsafe.arrayBaseOffset(byte[].class);
-    static final int UNSAFE_INT_BASE = unsafe.arrayBaseOffset(int[].class);
+    static final long UNSAFE_BYTE_BASE = unsafe.arrayBaseOffset(byte[].class);
+    static final long UNSAFE_INT_BASE = unsafe.arrayBaseOffset(int[].class);
 
     MemorySegment segment, alignedSegment;
     byte[] base;

--- a/test/micro/org/openjdk/bench/java/lang/foreign/xor/GetArrayUnsafeXorOpImpl.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/xor/GetArrayUnsafeXorOpImpl.java
@@ -42,7 +42,7 @@ import static org.openjdk.bench.java.lang.foreign.CLayouts.*;
 public class GetArrayUnsafeXorOpImpl implements XorOp {
 
     static final Unsafe UNSAFE = Utils.unsafe;
-    static final int BYTE_ARR_OFFSET = Utils.unsafe.arrayBaseOffset(byte[].class);
+    static final long BYTE_ARR_OFFSET = Utils.unsafe.arrayBaseOffset(byte[].class);
 
     static {
         System.loadLibrary("jnitest");


### PR DESCRIPTION
You can merge JDK's master first; then this PR will be clean.

The changes are:
1. `Unsafe::arrayBaseOffset(Class)` now returns `long`
2. `Unsafe.INVALID_FIELD_OFFSET` is now `long`
3. Associated test updates